### PR TITLE
fix: Store category count sync for multiple language

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -639,7 +639,7 @@ class Dokan_WPML {
     }
 
     /**
-     * Set store categories with translation to store.
+     * Set store categories with default language to store.
      *
      * @since 1.1.3
      *
@@ -648,20 +648,17 @@ class Dokan_WPML {
      * @return array
      */
     public function set_translated_category( $categories ) {
-        if ( ! function_exists( 'wpml_object_id_filter' ) || ! function_exists( 'wpml_get_active_languages' ) ) {
+        if ( ! function_exists( 'wpml_object_id_filter' ) || ! function_exists( 'wpml_get_default_language' ) ) {
             return $categories;
         }
 
-        $languages      = wpml_get_active_languages();
         $all_categories = [];
 
         foreach ( $categories as $store_cat_id ) {
-            foreach ( $languages as $language ) {
-                $translated_cat_id = wpml_object_id_filter( $store_cat_id, 'store_category', true, $language['code'] );
+            $translated_cat_id = wpml_object_id_filter( $store_cat_id, 'store_category', true, wpml_get_default_language() );
 
-                if ( ! in_array( $translated_cat_id, $all_categories ) ) {
-                    $all_categories[] = $translated_cat_id;
-                }
+            if ( ! in_array( $translated_cat_id, $all_categories ) ) {
+                $all_categories[] = $translated_cat_id;
             }
         }
 
@@ -717,6 +714,7 @@ class Dokan_WPML {
 
         return $this->get_product_id_in_base_language( absint( $meta_value ) );
     }
+
     /**
      * Dokan get base product id from translated product id.
      *

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -649,21 +649,21 @@ class Dokan_WPML {
      * @return array
      */
     public function set_translated_category( $categories ) {
-        if ( ! function_exists( 'wpml_object_id_filter' ) || ! function_exists( 'wpml_get_default_language' ) ) {
+        if ( ! function_exists( 'wpml_object_id_filter' ) || ! function_exists( 'wpml_get_active_languages' ) ) {
             return $categories;
         }
 
         $all_categories = [];
+        $languages      = wpml_get_active_languages();
 
         foreach ( $categories as $store_cat_id ) {
-            $translated_cat_id = wpml_object_id_filter( $store_cat_id, 'store_category', true, wpml_get_default_language() );
-
-            if ( ! in_array( $translated_cat_id, $all_categories ) ) {
+            foreach ( $languages as $code => $language ) {
+                $translated_cat_id = wpml_object_id_filter( $store_cat_id, 'store_category', true, $code );
                 $all_categories[] = $translated_cat_id;
             }
         }
 
-        return $all_categories;
+        return array_unique( $all_categories );
     }
 
     /**
@@ -960,7 +960,7 @@ class Dokan_WPML {
         if (
             ! function_exists( 'dokan_is_store_categories_feature_on' ) ||
             ! dokan_is_store_categories_feature_on() ||
-            ! dokan_pro()->store_category ) {
+            ! empty( dokan_pro()->store_category ) ) {
             return;
         }
 

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -17,4 +17,7 @@
         <custom-field action="copy">_dokan_advertisement_slot_count</custom-field>
         <custom-field action="copy">_dokan_advertisement_validity</custom-field>
     </custom-fields>
+    <taxonomies>
+        <taxonomy translate="2">store_category</taxonomy>
+    </taxonomies>
 </wpml-config>


### PR DESCRIPTION
Implemented Store category saving and fetching filters.

This will help syncing and preserving Category count.

* fix: https://github.com/getdokan/dokan-wpml/issues/53
* Related PR https://github.com/getdokan/dokan-pro/pull/3269


```php
        add_filter( 'dokan_set_store_categories', [ $this, 'set_translated_category' ] );
        add_filter( 'dokan_get_store_categories_in_vendor', [ $this, 'get_translated_category' ] );


    /**
     * Set store categories with default language to store.
     *
     * @since 1.1.3
     *
     * @param array $categories Store Categories.
     *
     * @return array
     */
    public function set_translated_category( $categories ) {
        if ( ! function_exists( 'wpml_object_id_filter' ) || ! function_exists( 'wpml_get_default_language' ) ) {
            return $categories;
        }

        $all_categories = [];

        foreach ( $categories as $store_cat_id ) {
            $translated_cat_id = wpml_object_id_filter( $store_cat_id, 'store_category', true, wpml_get_default_language() );

            if ( ! in_array( $translated_cat_id, $all_categories ) ) {
                $all_categories[] = $translated_cat_id;
            }
        }

        return $all_categories;
    }

    /**
     * Get store categories with current translation to store.
     *
     * @since 1.1.3
     *
     * @param WP_Term[] $categories Store Categories.
     *
     * @return array
     */
    public function get_translated_category( $categories ) {
        if ( ! function_exists( 'wpml_object_id_filter' ) ) {
            return $categories;
        }

        $category_ids = array_unique(
            array_map(
                function ( $store_cat ) {
                    return wpml_object_id_filter( $store_cat->term_id, 'store_category', true, null );
                    },
                $categories
            )
        );

        return array_map(
            function ( $category_id ) {
                return get_term( $category_id, 'store_category' );
            },
            $category_ids
        );
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced multilingual support by introducing translated store categories.
  
- **Improvements**
  - Improved configuration for multilingual taxonomy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->