### PR TITLE
Apply WPML delete post actions to the Dokan dashboard.

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -198,7 +198,10 @@ class Dokan_WPML {
         add_action( 'dokan_after_saving_settings', [ $this, 'register_single_store_custom_endpoint' ], 10, 3 );
         add_action( 'dokan_rewrite_rules_loaded', [ $this, 'handle_translated_single_store_endpoint_rewrite' ] );
         add_action( 'wpml_st_add_string_translation', [ $this, 'handle_single_store_endpoint_translation_update' ] );
-    }
+
+		add_action( 'dokan_product_delete', [ $this, 'before_product_delete' ] );
+		add_action( 'dokan_product_bulk_delete', [ $this, 'before_product_delete' ] );
+	}
 
 	/**
 	 * Initialize the plugin tracker
@@ -1808,6 +1811,20 @@ class Dokan_WPML {
             )
         );
     }
+
+		/**
+		 * Support WPML delete post actions on the frontend dashboard.
+		 *
+		 * @since 1.1.7
+		 *
+		 * @return void
+		 */
+		public function before_product_delete() {
+			if ( class_exists( 'WPML_Frontend_Post_Actions' ) ) {
+				global $wpml_post_translations;
+				add_action( 'delete_post', [ $wpml_post_translations, 'delete_post_actions' ] );
+			}
+		}
 } // Dokan_WPML
 
 function dokan_load_wpml() { // phpcs:ignore


### PR DESCRIPTION
Using the actions introduced in https://github.com/getdokan/dokan/pull/2368, enable the WPML post delete actions when deleting posts from the Dokan dashboard.

Closes https://github.com/getdokan/dokan-wpml/issues/82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced product deletion functionality to manage associated translations in multilingual setups.
	- Introduced new action hooks for individual and bulk product deletions.

These changes improve the coherence of multilingual content management within the Dokan plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->