### PR TITLE
fix: widget and verification page help text translate issue fixed

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1289,7 +1289,7 @@ class Dokan_WPML {
      * @return string
      */
     public function get_translated_verification_method_help_text( $help_text ) {
-        return $this->get_translated_single_string( $help_text, 'dokan', 'Dokan Vendor Verification Method Help Text: ' . $help_text );
+        return $this->get_translated_single_string( $help_text, 'dokan', 'Dokan Vendor Verification Method Help Text: ' . substr( $help_text, 0, 116 ) );
     }
 } // Dokan_WPML
 


### PR DESCRIPTION
Help text couldn't search long text as a key. So I limited the range, fixing the translation issue.

### Closes 

* https://github.com/getdokan/client-issue/issues/182

### Before & After Changes

![image](https://github.com/user-attachments/assets/4f239559-66ab-4409-acbb-80489da4921b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the vendor verification help text translation by truncating the text to improve readability.

- **Bug Fixes**
	- Adjusted the help text length for vendor verification methods to ensure clarity in translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->