### PR TITLE
fix: vendor vacation, biography `dokan-pro` support

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -171,7 +171,7 @@ class Dokan_WPML {
         add_filter( 'dokan_get_store_categories_in_vendor', [ $this, 'get_translated_category' ] );
 
         add_action( 'dokan_vendor_vacation_message_updated', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3 );
-        add_action( 'dokan_vendor_vacation_message_schedule_after_update', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3 );
+        add_action( 'dokan_vendor_vacation_message_schedule_updated', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3 );
         add_filter( 'dokan_get_vendor_vacation_message', [ $this, 'get_translated_dokan_vendor_vacation_message' ], 10, 2 );
 
         add_action( 'dokan_vendor_biography_after_update', [ $this, 'dokan_vendor_biography_updated' ], 10, 3 );

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -169,6 +169,13 @@ class Dokan_WPML {
         add_filter( 'wp', [ $this, 'set_translated_query_var_to_default_query_var' ], 11 );
         add_filter( 'dokan_set_store_categories', [ $this, 'set_translated_category' ] );
         add_filter( 'dokan_get_store_categories_in_vendor', [ $this, 'get_translated_category' ] );
+
+        add_action( 'dokan_vendor_vacation_message_updated', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3);
+        add_filter( 'dokan_get_vendor_vacation_message', [ $this, 'get_translated_dokan_vendor_vacation_message' ], 10, 2 );
+
+        add_action( 'dokan_vendor_biography_updated', [ $this, 'dokan_vendor_biography_updated' ], 10, 3);
+        add_filter( 'dokan_get_vendor_biography_text', [ $this, 'get_translated_dokan_vendor_biography_text' ], 10, 2 );
+
 	}
 
 	/**
@@ -1316,6 +1323,64 @@ class Dokan_WPML {
     public function get_translated_verification_method_help_text( $help_text ) {
         return $this->get_translated_single_string( $help_text, 'dokan', 'Dokan Vendor Verification Method Help Text: ' . substr( $help_text, 0, 116 ) );
     }
+
+    /**
+     * Translate Vendor Vacation Message
+     *
+     * @param $text
+     * @param $name
+     *
+     * @return void
+     */
+    public function dokan_vendor_vacation_message_updated($text, $name) {
+        $this->register_single_string(
+            'dokan',
+            'Vendor Vacation Message: ' . $name,
+            $text
+        );
+    }
+
+    /**
+     * Translated Vendor Vacation Message
+     *
+     * @param string $text
+     * @param $name
+     *
+     * @return string
+     */
+    public function get_translated_dokan_vendor_vacation_message(string $text , $name) {
+        return $this->get_translated_single_string( $text, 'dokan', 'Vendor Vacation Message: '.$name );
+    }
+
+
+    /**
+     * Translate Vendor Biography Text
+     *
+     * @param $text
+     * @param $name
+     *
+     * @return void
+     */
+    public function dokan_vendor_biography_updated($text, $name) {
+        $this->register_single_string(
+            'dokan',
+            'Vendor Biography Text: ' . $name,
+            $text
+        );
+    }
+
+    /**
+     * Translated Vendor Biography Text
+     *
+     * @param string $text
+     * @param $name
+     *
+     * @return string
+     */
+    public function get_translated_dokan_vendor_biography_text(string $text , $name) {
+        return $this->get_translated_single_string( $text, 'dokan', 'Vendor Biography Text: '.$name );
+    }
+
 } // Dokan_WPML
 
 function dokan_load_wpml() { // phpcs:ignore

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -171,10 +171,10 @@ class Dokan_WPML {
         add_filter( 'dokan_get_store_categories_in_vendor', [ $this, 'get_translated_category' ] );
 
         add_action( 'dokan_vendor_vacation_message_updated', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3 );
-        add_action( 'dokan_vendor_vacation_message_schedule_updated', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3 );
+        add_action( 'dokan_vendor_vacation_message_schedule_after_update', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3 );
         add_filter( 'dokan_get_vendor_vacation_message', [ $this, 'get_translated_dokan_vendor_vacation_message' ], 10, 2 );
 
-        add_action( 'dokan_vendor_biography_updated', [ $this, 'dokan_vendor_biography_updated' ], 10, 3 );
+        add_action( 'dokan_vendor_biography_after_update', [ $this, 'dokan_vendor_biography_updated' ], 10, 3 );
         add_filter( 'dokan_get_vendor_biography_text', [ $this, 'get_translated_dokan_vendor_biography_text' ], 10, 2 );
 	}
 
@@ -1356,16 +1356,16 @@ class Dokan_WPML {
     /**
      * Translate Vendor Biography Text
      *
-     * @param $text
-     * @param $name
+     * @param $store_info array
+     * @param $name string
      *
      * @return void
      */
-    public function dokan_vendor_biography_updated($text, $name) {
+    public function dokan_vendor_biography_updated($store_info, $name) {
         $this->register_single_string(
             'dokan',
             'Vendor Biography Text: ' . $name,
-            $text
+            $store_info['vendor_biography']
         );
     }
 

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -127,9 +127,9 @@ class Dokan_WPML {
 		add_filter( 'dokan_force_page_redirect', [ $this, 'force_redirect_page' ], 90, 2 );
 
 		// Load all filters hook
-        add_filter('sanitize_user_meta_product_package_id', [ $this, 'set_subscription_pack_id_in_base_language' ], 10, 3 );
-        add_filter('dokan_vendor_subscription_package_title', [ $this, 'vendor_subscription_pack_title_translation' ], 10, 2 );
-        add_filter('dokan_vendor_subscription_package_id', [ $this, 'get_product_id_in_base_language' ] );
+        add_filter( 'sanitize_user_meta_product_package_id', [ $this, 'set_subscription_pack_id_in_base_language' ], 10, 3 );
+        add_filter( 'dokan_vendor_subscription_package_title', [ $this, 'vendor_subscription_pack_title_translation' ], 10, 2 );
+        add_filter( 'dokan_vendor_subscription_package_id', [ $this, 'get_product_id_in_base_language' ] );
 		add_filter( 'dokan_get_navigation_url', [ $this, 'load_translated_url' ], 10, 2 );
 		add_filter( 'body_class', [ $this, 'add_dashboard_template_class_if_wpml' ], 99 );
 		add_filter( 'dokan_get_current_page_id', [ $this, 'dokan_set_current_page_id' ] );
@@ -141,8 +141,8 @@ class Dokan_WPML {
 		add_filter( 'dokan_dashboard_nav_menu_key', [ $this, 'filter_dashboard_settings_key' ] );
 		add_filter( 'dokan_dashboard_nav_submenu_key', [ $this, 'filter_dashboard_settings_key' ] );
 		add_filter( 'wcml_vendor_addon_configuration', [ $this, 'add_vendor_capability' ] );
-        add_filter('icl_lang_sel_copy_parameters', [ $this, 'set_language_switcher_copy_param' ] );
-        add_filter( 'dokan_vendor_subscription_product_count_query', [ $this, 'set_vendor_subscription_product_count_query' ],10 ,3 );
+        add_filter( 'icl_lang_sel_copy_parameters', [ $this, 'set_language_switcher_copy_param' ] );
+        add_filter( 'dokan_vendor_subscription_product_count_query', [ $this, 'set_vendor_subscription_product_count_query' ], 10, 3 );
 
 		add_action( 'init', [ $this, 'fix_store_category_query_arg' ], 10 );
 		add_action( 'init', [ $this, 'load_wpml_admin_post_actions' ], 10 );
@@ -157,8 +157,8 @@ class Dokan_WPML {
         add_filter( 'dokan_pro_abuse_report_reason', [ $this, 'get_translated_abuse_report_reason' ] );
         add_filter( 'dokan_pro_subscription_allowed_categories', [ $this, 'get_translated_allowed_categories' ] );
         add_filter( 'dokan_pro_rma_reason', [ $this, 'get_translated_rma_reason' ] );
-        add_action( 'dokan_pro_vendor_verification_method_created', [ $this, 'register_vendor_verification_method'] );
-        add_action( 'dokan_pro_vendor_verification_method_updated', [ $this, 'register_vendor_verification_method'] );
+        add_action( 'dokan_pro_vendor_verification_method_created', [ $this, 'register_vendor_verification_method' ] );
+        add_action( 'dokan_pro_vendor_verification_method_updated', [ $this, 'register_vendor_verification_method' ] );
         add_filter( 'dokan_pro_vendor_verification_method_title', [ $this, 'get_translated_verification_method_title' ] );
         add_filter( 'dokan_pro_vendor_verification_method_help_text', [ $this, 'get_translated_verification_method_help_text' ] );
 
@@ -170,12 +170,12 @@ class Dokan_WPML {
         add_filter( 'dokan_set_store_categories', [ $this, 'set_translated_category' ] );
         add_filter( 'dokan_get_store_categories_in_vendor', [ $this, 'get_translated_category' ] );
 
-        add_action( 'dokan_vendor_vacation_message_updated', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3);
+        add_action( 'dokan_vendor_vacation_message_updated', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3 );
+        add_action( 'dokan_vendor_vacation_message_schedule_updated', [ $this, 'dokan_vendor_vacation_message_updated' ], 10, 3 );
         add_filter( 'dokan_get_vendor_vacation_message', [ $this, 'get_translated_dokan_vendor_vacation_message' ], 10, 2 );
 
-        add_action( 'dokan_vendor_biography_updated', [ $this, 'dokan_vendor_biography_updated' ], 10, 3);
+        add_action( 'dokan_vendor_biography_updated', [ $this, 'dokan_vendor_biography_updated' ], 10, 3 );
         add_filter( 'dokan_get_vendor_biography_text', [ $this, 'get_translated_dokan_vendor_biography_text' ], 10, 2 );
-
 	}
 
 	/**


### PR DESCRIPTION
Related PR: [Link](https://github.com/getdokan/dokan-pro/pull/3870)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for managing vendor vacation messages and biographies, allowing for translation.
	- Added new actions and filters to facilitate the updating and retrieval of translated vendor content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->