### PR TITLE
fix: Dokan Category Wise Commission support added.

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -33,6 +33,11 @@
         <custom-field action="copy">_product_addons_exclude_global</custom-field>
         <custom-field action="copy">_product_addons</custom-field>
     </custom-fields>
+    <custom-term-fields>
+        <custom-term-field action="copy">per_category_admin_commission_type</custom-term-field>
+        <custom-term-field action="copy">per_category_admin_additional_fee</custom-term-field>
+        <custom-term-field action="copy">per_category_admin_commission</custom-term-field>
+    </custom-term-fields>
     <taxonomies>
         <taxonomy translate="2">store_category</taxonomy>
     </taxonomies>


### PR DESCRIPTION
Custom term meta translation support added for dokan category wise commission. 


### Closes 
* Closes #https://github.com/getdokan/dokan-wpml/issues/57

Before : 
![image](https://github.com/user-attachments/assets/2f4583f7-5704-41c5-b09f-7f89ffac1284)
After : 
![image](https://github.com/user-attachments/assets/772e358c-95f5-46e7-a2a4-b541b41d38f0)
