### PR TITLE
🚀 enhance: Dokan single store endpoint translation support

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1471,12 +1471,15 @@ class Dokan_WPML {
     public function handle_single_store_endpoint_translation_update( int $translated_string_id ) {
         $original_string_id = $this->get_original_string_id( $translated_string_id );
 
-
         if ( ! $original_string_id ) {
             return;
         }
 
         $original_string_value = $this->get_original_string_value( $original_string_id );
+
+        if ( ! $original_string_value ) {
+            return;
+        }
 
         $this->handle_translated_single_store_endpoint_rewrite( $original_string_value );
     }

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -171,7 +171,7 @@ class Dokan_WPML {
         add_filter( 'dokan_get_store_categories_in_vendor', [ $this, 'get_translated_category' ] );
 
         add_action( 'dokan_after_saving_settings', [ $this, 'register_vendor_store_url_slug' ], 10, 3 );
-        add_filter( 'dokan_store_url_slug', [ $this, 'get_translated_vendor_store_url_slug' ] );
+        add_filter( 'dokan_get_store_url', [ $this, 'get_translated_vendor_store_url_slug' ], 10, 2 );
 	}
 
     /**
@@ -196,12 +196,17 @@ class Dokan_WPML {
      *
      * @since 1.1.8
      *
-     * @param string $url_slug URL slug.
+     * @param string $store_url        Store URL.
+     * @param string $custom_url_slug Store URL slug.
      *
      * @return string
      */
-    public function get_translated_vendor_store_url_slug( $url_slug ) {
-        return $this->get_translated_single_string( $url_slug, 'dokan-lite', 'Dokan vendor store URL slug' );
+    public function get_translated_vendor_store_url_slug( $store_url, $custom_url_slug ) {
+        return str_replace(
+            $custom_url_slug,
+            $this->get_translated_single_string( $custom_url_slug, 'dokan-lite', 'Dokan vendor store URL slug' ),
+            $store_url
+        );
     }
 
 	/**

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -579,7 +579,7 @@ class Dokan_WPML {
 
         $store_url = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
 
-        if ( ! in_array( $store_url, $query_vars ) ) {
+        if ( ! isset( $query_vars[ $store_url ] ) ) {
             $query_vars[] = $store_url;
         }
 
@@ -1527,15 +1527,18 @@ class Dokan_WPML {
         }
 
         try {
-            icl_register_string(
+            $this->register_single_string(
                 $this->wp_endpoints,
                 $option_value['custom_store_url'],
                 $option_value['custom_store_url'],
-                false,
-                wpml_get_default_language()
             );
         } catch ( Exception $e ) {
-            dokan_log( 'Dokan WPML - Error on registering vendor store URL endpoint: ' . $e->getMessage() );
+            dokan_log(
+                sprintf(
+                    __( 'Dokan WPML - Error on registering vendor store URL endpoint: %s', 'dokan-wpml' ),
+                    $e->getMessage()
+                )
+            );
         }
     }
 
@@ -1590,6 +1593,14 @@ class Dokan_WPML {
      * @return void
      */
     public function add_rewrite_rules( string $regex_slug, string $query_slug, string $after = 'top' ) {
+        if ( empty( $regex_slug ) || empty( $query_slug ) ) {
+            return;
+        }
+
+        if ( ! in_array( $after, [ 'top', 'bottom' ], true ) ) {
+            $after = 'top';
+        }
+
         add_rewrite_rule( $regex_slug . '/([^/]+)/?$', 'index.php?' . $query_slug . '=$matches[1]', $after );
         add_rewrite_rule( $regex_slug . '/([^/]+)/page/?([0-9]{1,})/?$', 'index.php?' . $query_slug . '=$matches[1]&paged=$matches[2]', $after );
 

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -169,7 +169,40 @@ class Dokan_WPML {
         add_filter( 'wp', [ $this, 'set_translated_query_var_to_default_query_var' ], 11 );
         add_filter( 'dokan_set_store_categories', [ $this, 'set_translated_category' ] );
         add_filter( 'dokan_get_store_categories_in_vendor', [ $this, 'get_translated_category' ] );
+
+        add_action( 'dokan_after_saving_settings', [ $this, 'register_vendor_store_url_slug' ], 10, 3 );
+        add_filter( 'dokan_store_url_slug', [ $this, 'get_translated_vendor_store_url_slug' ] );
 	}
+
+    /**
+     * Register Vendor Store URL Slug.
+     *
+     * @since 1.1.8
+     *
+     * @param string $option_name URL slug.
+     * @param array $option_value URL slug.
+     * @param array $old_options URL slug.
+     *
+     * @return void
+     */
+    public function register_vendor_store_url_slug( string $option_name, array $option_value, array $old_options) {
+        if ( 'dokan_general' === $option_name && isset( $old_options['custom_store_url'] ) && $old_options['custom_store_url'] !== $option_value['custom_store_url'] ) {
+            $this->register_single_string( 'dokan-lite', 'Dokan vendor store URL slug', $option_value['custom_store_url'] );
+        }
+    }
+
+    /**
+     * Get Translated Vendor Store URL Slug.
+     *
+     * @since 1.1.8
+     *
+     * @param string $url_slug URL slug.
+     *
+     * @return string
+     */
+    public function get_translated_vendor_store_url_slug( $url_slug ) {
+        return $this->get_translated_single_string( $url_slug, 'dokan-lite', 'Dokan vendor store URL slug' );
+    }
 
 	/**
 	 * Initialize the plugin tracker


### PR DESCRIPTION
Translation support added for Dokan single store translation support.

* Closes: #58 


### How to test the changes in this Pull Request:

* Please follow the steps from: #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced multilingual support for single store endpoints.
	- Improved translation handling for store URLs.
	- Added advanced endpoint registration and translation management for WPML compatibility.
	- New methods for managing single store endpoint translations and rewrite rules.

- **Improvements**
	- More robust handling of store endpoint translations.
	- Better management of URL rewriting for multilingual stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->