### PR TITLE
enhance: Dokan submenu translation support for wpml language switcher.

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1520,7 +1520,10 @@ class Dokan_WPML {
 
         return apply_filters(
             'dokan_wpml_get_language_switcher_url',
-            trailingslashit( $base_url ) . trailingslashit( implode( '/', $path_segments ) )
+            trailingslashit( $base_url ) . trailingslashit( implode( '/', $path_segments ) ),
+            $path_segments,
+            $lang,
+            $base_url
         );
     }
 
@@ -1535,7 +1538,7 @@ class Dokan_WPML {
      * @return array Translated path segments
      */
     protected function translate_path_segments( $path_segments, $lang_code ) {
-        foreach( $path_segments as $key => $segment ) {
+        foreach ( $path_segments as $key => $segment ) {
             $path_segments[ $key ] = $this->translate_endpoint( urldecode_deep( $segment ), $lang_code );
         }
 

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -896,8 +896,8 @@ class Dokan_WPML {
 		$store_user       = get_user_by( 'slug', $store_slug );
 		$store_url        = dokan_get_store_url( $store_user->ID );
 
-		add_filter( 'wpml_ls_language_url', function( $url, $lang ) use ( $store_url, $store_user ) {
-		    return apply_filters( 'wpml_permalink', $store_url, $lang['code'] );
+		add_filter( 'wpml_ls_language_url', function( $url, $data ) use ( $store_url ) {
+		    return apply_filters( 'wpml_permalink', $store_url, $data['code'] );
 	    }, 10, 2 );
     }
 

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -516,6 +516,8 @@ class Dokan_WPML {
      *
      * @since 1.1.1
      *
+     * @param string|null $lang
+     *
      * @return array
      */
     public function get_translated_query_vars_map( $lang = null ): array {
@@ -555,8 +557,6 @@ class Dokan_WPML {
             'toc',
             'biography',
             'reviews',
-            'settings',
-            'dashboard',
         ];
 
         $query_vars = apply_filters( 'dokan_wpml_settings_query_var_map', $query_vars );
@@ -1539,7 +1539,7 @@ class Dokan_WPML {
             $path_segments[0] = $dashboard_translated_slug;
         }
 
-        // Translate additional path segments.
+        // Translate path segments to the target language.
         $path_segments = $this->translate_path_segments( $path_segments, $lang['code'] );
 
         return trailingslashit( $base_url ) . trailingslashit( implode( '/', $path_segments ) );
@@ -1556,13 +1556,10 @@ class Dokan_WPML {
      * @return array Translated path segments
      */
     protected function translate_path_segments( $path_segments, $lang_code ) {
-        $segment_count = min( count( $path_segments ), 3 );
+        $segment_count = count( $path_segments );
 
         for ( $i = 1; $i < $segment_count; $i++ ) {
-            if ( ! empty( $path_segments[ $i ] ) ) {
-                $default_var         = $this->get_default_query_var( urldecode_deep( $path_segments[ $i ] ) );
-                $path_segments[ $i ] = $this->translate_endpoint( $default_var, $lang_code );
-            }
+            $path_segments[ $i ] = $this->translate_endpoint( urldecode_deep( $path_segments[ $i ] ), $lang_code );
         }
 
         return $path_segments;

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -181,7 +181,7 @@ class Dokan_WPML {
         add_filter( 'dokan_get_vendor_biography_text', [ $this, 'get_translated_dokan_vendor_biography_text' ], 10, 2 );
 
         // Add URL translation support for language switcher.
-        add_filter( 'wpml_ls_language_url', [ $this, 'filter_language_switcher_url' ], 10, 2 );
+        add_filter( 'wpml_ls_language_url', [ $this, 'filter_language_switcher_url' ], 99, 2 );
 	}
 
 	/**

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1515,13 +1515,14 @@ class Dokan_WPML {
         }
 
         // Translate path segments to the target language.
-        $path_segments = explode( '/', $url_path );
-        $path_segments = $this->translate_path_segments( $path_segments, $lang['code'] );
+        $path_segments       = explode( '/', $url_path );
+        $translated_segments = $this->translate_path_segments( $path_segments, $lang['code'] );
 
         return apply_filters(
             'dokan_wpml_get_language_switcher_url',
-            trailingslashit( $base_url ) . trailingslashit( implode( '/', $path_segments ) ),
+            trailingslashit( $base_url ) . trailingslashit( implode( '/', $translated_segments ) ),
             $path_segments,
+            $translated_segments,
             $lang,
             $base_url
         );

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -180,6 +180,7 @@ class Dokan_WPML {
         add_action( 'dokan_vendor_biography_after_update', [ $this, 'dokan_vendor_biography_updated' ], 10, 3 );
         add_filter( 'dokan_get_vendor_biography_text', [ $this, 'get_translated_dokan_vendor_biography_text' ], 10, 2 );
 
+        // Add URL translation support for language switcher.
         add_filter( 'wpml_ls_language_url', [ $this, 'filter_language_switcher_url' ], 10, 2 );
 	}
 
@@ -557,6 +558,7 @@ class Dokan_WPML {
             'toc',
             'biography',
             'reviews',
+
         ];
 
         $query_vars = apply_filters( 'dokan_wpml_settings_query_var_map', $query_vars );
@@ -895,7 +897,6 @@ class Dokan_WPML {
 		$store_url        = dokan_get_store_url( $store_user->ID );
 
 		add_filter( 'wpml_ls_language_url', function( $url, $lang ) use ( $store_url, $store_user ) {
-
 		    return apply_filters( 'wpml_permalink', $store_url, $lang['code'] );
 	    }, 10, 2 );
     }
@@ -1333,8 +1334,7 @@ class Dokan_WPML {
      * @return string
      */
     public function get_default_query_var( $query_var, $lang = null ) {
-        $query_var_map = $this->get_translated_query_vars_map( $lang );
-
+        $query_var_map     = $this->get_translated_query_vars_map( $lang );
         $default_query_var = array_search( $query_var, $query_var_map, true );
 
         if ( false === $default_query_var ) {
@@ -1564,7 +1564,6 @@ class Dokan_WPML {
 
         return $path_segments;
     }
-
 } // Dokan_WPML
 
 function dokan_load_wpml() { // phpcs:ignore

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1514,35 +1514,14 @@ class Dokan_WPML {
             return $url;
         }
 
-        $path_segments = explode( '/', $url_path );
-        $base_slug     = urldecode_deep( $path_segments[0] );
-
-        // Get store and dashboard slugs.
-        $store_slug                = dokan_get_option( 'custom_store_url', 'dokan_general', 'store' );
-        $dashboard_page_id         = $this->get_raw_option( 'dashboard', 'dokan_pages' );
-        $dashboard_translated_id   = wpml_object_id_filter( $dashboard_page_id, 'page', true, $lang['code'] );
-        $dashboard_translated_slug = urldecode_deep( get_post_field( 'post_name', $dashboard_translated_id ) );
-
-        // Check if the URL is a store URL or a dashboard URL.
-        $is_store_url     = $base_slug === $this->get_default_query_var( $store_slug );
-        $is_dashboard_url = $base_slug === $dashboard_translated_slug;
-
-        if ( ! $is_store_url && ! $is_dashboard_url ) {
-            return $url;
-        }
-
-        if ( $is_store_url ) {
-            $path_segments[0] = $this->translate_endpoint( $store_slug, $lang['code'] );
-        }
-
-        if ( $is_dashboard_url ) {
-            $path_segments[0] = $dashboard_translated_slug;
-        }
-
         // Translate path segments to the target language.
+        $path_segments = explode( '/', $url_path );
         $path_segments = $this->translate_path_segments( $path_segments, $lang['code'] );
 
-        return trailingslashit( $base_url ) . trailingslashit( implode( '/', $path_segments ) );
+        return apply_filters(
+            'dokan_wpml_get_language_switcher_url',
+            trailingslashit( $base_url ) . trailingslashit( implode( '/', $path_segments ) )
+        );
     }
 
     /**
@@ -1556,10 +1535,8 @@ class Dokan_WPML {
      * @return array Translated path segments
      */
     protected function translate_path_segments( $path_segments, $lang_code ) {
-        $segment_count = count( $path_segments );
-
-        for ( $i = 1; $i < $segment_count; $i++ ) {
-            $path_segments[ $i ] = $this->translate_endpoint( urldecode_deep( $path_segments[ $i ] ), $lang_code );
+        foreach( $path_segments as $key => $segment ) {
+            $path_segments[ $key ] = $this->translate_endpoint( urldecode_deep( $segment ), $lang_code );
         }
 
         return $path_segments;

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1905,7 +1905,7 @@ class Dokan_WPML {
      *
      * @return array Translated path segments
      */
-    protected function translate_path_segments( $path_segments, $lang_code ) {
+    public function translate_path_segments( $path_segments, $lang_code ) {
         foreach ( $path_segments as $key => $segment ) {
             $path_segments[ $key ] = $this->translate_endpoint( urldecode_deep( $segment ), $lang_code );
         }


### PR DESCRIPTION
Implement translation support for dokan sub-menu URL using language switcher.

Related PR: [#94](https://github.com/getdokan/dokan-wpml/pull/94)

- Closes https://github.com/getdokan/dokan-pro/issues/3419

https://github.com/user-attachments/assets/504f2e78-12ed-4b33-97cd-ee3ddf6e77ba

## Summary by CodeRabbit

- **New Features**
  - Enhanced multilingual support to ensure smooth language switching for store and dashboard pages.
  - Introduced dynamic URL translation and improved handling of language-specific query parameters, providing a more intuitive navigation experience when switching languages. 
  - Added a filter for language switcher URLs to facilitate better URL management based on selected languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->