### PR TITLE
enhance: Support shipping `zone_id` and `instance_id` to dashboard URL query parameters.

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -656,6 +656,8 @@ class Dokan_WPML {
             'ticket_keyword',
             'ticket_status',
             'dokan-support-listing-search-nonce',
+	        'zone_id',
+	        'instance_id',
         ];
 
         return array_merge( $params, $dokan_params );


### PR DESCRIPTION
This pull request makes a small update to the `set_language_switcher_copy_param` function in `dokan-wpml.php`, adding two new parameters to the list that are copied by the language switcher.

- Added `zone_id` and `instance_id` to the list of parameters handled by the language switcher in `set_language_switcher_copy_param`.

**Closes: https://github.com/getdokan/dokan-wpml/issues/104**

Changelog: Added support for `zone_id` and `instance_id` parameters for dokan shipping URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Language switcher now forwards additional parameters to preserve context when changing languages.
  - Specifically, shipping zone and shipping method instance are retained across language switches for a smoother, more consistent browsing experience.
  - No changes to existing behaviors or settings are required; the enhancement works automatically without user action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->