### PR TITLE
fix/duplicate-queries-vendor-dashboard-dokan-wpml

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -50,7 +50,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class Dokan_WPML {
     /*
-     * Cached options
+     * Cached options.
      *
      * @var array
      */
@@ -220,8 +220,8 @@ class Dokan_WPML {
 	}
     
     /**
-     * Clear cache when option is updated, added, or deleted
-     * This function accepts variable parameters to work with all three hooks
+     * Clear cache when option is updated, added, or deleted.
+     * This function accepts variable parameters to work with all three hooks.
      * 
      * @since 1.1.13
      * 
@@ -230,7 +230,7 @@ class Dokan_WPML {
      * @return void
      */
     public function clear_option_cache( $option ) {
-        // Clear only if dokan_pages option is affected.
+        // Clear only if the option exists in cache.
         if ( empty( self::$cached_options[ $option ] ) ) {
             return;
         }

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -49,6 +49,12 @@ defined( 'ABSPATH' ) || exit;
  * @class Dokan_WPML The class that holds the entire Dokan_WPML plugin
  */
 class Dokan_WPML {
+    /*
+     * Cached options
+     *
+     * @var array
+     */
+    private $cached_options = [];
 
     /*
      * WordPress Endpoints text domain
@@ -1005,16 +1011,25 @@ class Dokan_WPML {
      * @return mixed
      */
     public function get_raw_option( $option, $section, $default = '' ) {
+        $cache_key = $section . '_' . $option;
+
+        if ( isset( $this->cached_options[$cache_key] ) ) {
+            return $this->cached_options[$cache_key];
+        }
+
         if ( ! class_exists( 'WPML_Multilingual_Options_Utils' ) ) {
             return dokan_get_option( $option, $section, $default );
         }
 
         global $wpdb;
-
         $util    = new WPML_Multilingual_Options_Utils( $wpdb );
         $options = $util->get_option_without_filtering( $section );
 
-        return isset( $options[ $option ] ) ? $options[ $option ] : $default;
+        $result = isset( $options[$option] ) ? $options[$option] : $default;
+
+        $this->cached_options[$cache_key] = $result;
+
+        return $result;
     }
 
     /**

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -592,7 +592,6 @@ class Dokan_WPML {
      */
     public function get_dokan_url_for_language( $language, $name = '' ) {
         $post_id      = $this->get_raw_option( 'dashboard', 'dokan_pages' );
-        error_log('Post ID: ' . $post_id);
         $lang_post_id = '';
 
         if ( function_exists( 'wpml_object_id_filter' ) ) {

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -89,6 +89,11 @@ class Dokan_WPML {
 
 		// load all actions and filter under plugins loaded hooks
 	    add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
+
+        // Clear option cache on option updates, additions, deletions
+        add_action( 'updated_option', [ $this, 'clear_option_cache' ], 10, 3 );
+        add_action( 'added_option', [ $this, 'clear_option_cache' ], 10, 3 );
+        add_action( 'deleted_option', [ $this, 'clear_option_cache' ], 10, 3 );
     }
 
     /**
@@ -213,6 +218,21 @@ class Dokan_WPML {
 
         add_action( 'wp_enqueue_scripts', [ $this, 'enqueue' ] );
 	}
+    
+    /**
+     * Clear cache when option is updated, added, or deleted
+     * This function accepts variable parameters to work with all three hooks
+     * 
+     * @param string $option_name Name of the option
+     * @param mixed  $param2      Old value (for updated_option) or value (for added_option) - optional
+     * @param mixed  $param3      New value (for updated_option) - optional
+     */
+    public function clear_option_cache( $option, $param2 = null, $param3 = null ) {
+        // Clear only if dokan_pages option is affected
+        if ( $option === 'dokan_pages' ) {
+           $this->cached_options = [];
+        }
+    }
 
 	/**
 	 * Initialize the plugin tracker

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -54,7 +54,7 @@ class Dokan_WPML {
      *
      * @var array
      */
-    private $cached_options = [];
+    private static $cached_options = [];
 
     /*
      * WordPress Endpoints text domain
@@ -91,9 +91,9 @@ class Dokan_WPML {
 	    add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ] );
 
         // Clear option cache on option updates, additions, deletions
-        add_action( 'updated_option', [ $this, 'clear_option_cache' ], 10, 3 );
-        add_action( 'added_option', [ $this, 'clear_option_cache' ], 10, 3 );
-        add_action( 'deleted_option', [ $this, 'clear_option_cache' ], 10, 3 );
+        add_action( 'updated_option', [ $this, 'clear_option_cache' ] );
+        add_action( 'added_option', [ $this, 'clear_option_cache' ] );
+        add_action( 'deleted_option', [ $this, 'clear_option_cache' ] );
     }
 
     /**
@@ -223,15 +223,19 @@ class Dokan_WPML {
      * Clear cache when option is updated, added, or deleted
      * This function accepts variable parameters to work with all three hooks
      * 
-     * @param string $option_name Name of the option
-     * @param mixed  $param2      Old value (for updated_option) or value (for added_option) - optional
-     * @param mixed  $param3      New value (for updated_option) - optional
+     * @since 1.1.13
+     * 
+     * @param string $option Name of the option
+     * 
+     * @return void
      */
-    public function clear_option_cache( $option, $param2 = null, $param3 = null ) {
-        // Clear only if dokan_pages option is affected
-        if ( $option === 'dokan_pages' ) {
-           $this->cached_options = [];
+    public function clear_option_cache( $option ) {
+        // Clear only if dokan_pages option is affected.
+        if ( empty( self::$cached_options[ $option ] ) ) {
+            return;
         }
+
+        unset( self::$cached_options[ $option ] );
     }
 
 	/**
@@ -588,6 +592,7 @@ class Dokan_WPML {
      */
     public function get_dokan_url_for_language( $language, $name = '' ) {
         $post_id      = $this->get_raw_option( 'dashboard', 'dokan_pages' );
+        error_log('Post ID: ' . $post_id);
         $lang_post_id = '';
 
         if ( function_exists( 'wpml_object_id_filter' ) ) {
@@ -1031,10 +1036,8 @@ class Dokan_WPML {
      * @return mixed
      */
     public function get_raw_option( $option, $section, $default = '' ) {
-        $cache_key = $section . '_' . $option;
-
-        if ( isset( $this->cached_options[$cache_key] ) ) {
-            return $this->cached_options[$cache_key];
+        if ( isset( self::$cached_options[ $section ][ $option ] ) ) {
+            return self::$cached_options[ $section ][ $option ];
         }
 
         if ( ! class_exists( 'WPML_Multilingual_Options_Utils' ) ) {
@@ -1045,9 +1048,9 @@ class Dokan_WPML {
         $util    = new WPML_Multilingual_Options_Utils( $wpdb );
         $options = $util->get_option_without_filtering( $section );
 
-        $result = isset( $options[$option] ) ? $options[$option] : $default;
+        $result = $options[ $option ] ?? $default;
 
-        $this->cached_options[$cache_key] = $result;
+        self::$cached_options[ $section ][ $option ] = $result;
 
         return $result;
     }


### PR DESCRIPTION
### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added a caching layer to avoid redundant database queries. The query now executes only once, with subsequent calls fetching the cached result instead of hitting the database.

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes https://github.com/getdokan/dokan-pro/issues/5258#issue-3721767092


### How to test the changes in this Pull Request:
- Go to the Vendor Dashboard.
- Open Query Monitor and check the "Duplicate Queries" section.
- Look for the method WPML_Multilingual_Options_Utils->get_option_without_filtering().


### Changelog entry

*Title: Bug/Problem - Duplicate Queries Detected on Vendor Dashboard When Dokan WPML Is Enabled

### Before Changes

When Dokan WPML is active, Query Monitor reports duplicate database queries on the vendor dashboard. The duplicate calls originate from the method WPML_Multilingual_Options_Utils->get_option_without_filtering().


### After Changes
The vendor dashboard avoid unnecessary duplicate option queries, especially those triggered through WPML, to ensure optimal performance.


### Feature Video (optional)

**Video reference:** https://d.pr/v/Gaa2R9


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Implemented option caching to speed repeated settings lookups and reduce load.
  * Cached values are reused across requests to improve responsiveness.

* **Reliability / Bug Fixes**
  * Added automatic cache invalidation when related settings change so updates appear immediately.
  * Ensures users see the latest configuration without stale values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->