### PR TITLE
Fix broken language switcher URLs when WPML uses different domains per language

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1911,14 +1911,21 @@ class Dokan_WPML {
             return $url; // Return early if URL or language code is empty
         }
 
+        // Get language negotiation type
+        $language_negotiation_type = (int) apply_filters( 'wpml_setting', 1, 'language_negotiation_type' );
+            
+        // For domain-based language negotiation (type 2), WPML handles URLs correctly.
+        // This filter should not modify URLs in domain mode as it breaks the URL structure.
+        if ( WPML_LANGUAGE_NEGOTIATION_TYPE_DOMAIN === $language_negotiation_type ) {
+            return $url;
+        }
         // Get home URL without WPML modifications.
         $this->disable_url_translation();
         $home_url = home_url();
         $this->enable_url_translation();
 
-        // Get language negotiation type and build base URL
+        // Get default language code and check if the negotiation type is parameter-based.
         $default_language_code     = wpml_get_default_language();
-        $language_negotiation_type = (int) apply_filters( 'wpml_setting', 1, 'language_negotiation_type' );
         $is_parameter_based        = ( WPML_LANGUAGE_NEGOTIATION_TYPE_PARAMETER === $language_negotiation_type );
 
         // If the language negotiation type is parameter-based, we need to use the home URL as the base URL.

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1908,91 +1908,41 @@ class Dokan_WPML {
     public function filter_language_switcher_url( $url, $lang ) {
         $lang_code = $lang['code'] ?? '';
         if ( empty( $url ) || empty( $lang_code ) ) {
-            return $url; // Return early if URL or language code is empty
+            return $url; // Return early if URL or language code is empty.
         }
 
-        // Get language negotiation type
-        $language_negotiation_type = (int) apply_filters( 'wpml_setting', 1, 'language_negotiation_type' );
-        $is_parameter_based        = false;
-        $is_domain_based           = false;
-        if ( defined( 'WPML_LANGUAGE_NEGOTIATION_TYPE_PARAMETER' ) && defined( 'WPML_LANGUAGE_NEGOTIATION_TYPE_DOMAIN' ) ) {
-            $is_parameter_based = ( WPML_LANGUAGE_NEGOTIATION_TYPE_PARAMETER === $language_negotiation_type );
-            $is_domain_based    = ( WPML_LANGUAGE_NEGOTIATION_TYPE_DOMAIN === $language_negotiation_type );
+        $parsed_url = wp_parse_url( $url );
+        if ( ! is_array( $parsed_url ) || empty( $parsed_url['path'] ) ) {
+            return $url; // Nothing to translate (e.g. home URL).
         }
 
-        // Get home URL without WPML modifications
-        $this->disable_url_translation();
-        $home_url = home_url();
-        $this->enable_url_translation();
+        // WPML has already encoded the correct scheme/host/lang-prefix/query for the
+        // target language. We only need to translate the Dokan endpoint path segments;
+        // unrecognised segments (lang code, store names, page slugs) pass through unchanged.
+        $segments            = explode( '/', trim( $parsed_url['path'], '/' ) );
+        $translated_segments = $this->translate_path_segments( $segments, $lang_code );
 
-        // Extract path from URL
-        $parsed_url = parse_url( $url );
-        if ( ! is_array( $parsed_url ) ) {
-            return $url;
-        }
-        $url_path   = isset( $parsed_url['path'] ) ? trim( $parsed_url['path'], '/' ) : '';
-        
-        // Build base URL based on negotiation type
-        if ( $is_domain_based ) {
-            $domain_info = apply_filters( 'wpml_setting', [], 'language_domains' );
-            if ( ! empty( $domain_info[ $lang_code ] ) ) {
-                $base_url = $domain_info[ $lang_code ];
-                if ( ! preg_match( '#^https?://#i', $base_url ) ) {
-                    $scheme   = wp_parse_url( $home_url, PHP_URL_SCHEME ) ?: 'https';
-                    $base_url = $scheme . '://' . $base_url;
-                }
-            } else {
-                return $url;
-            }
-        } elseif ( $is_parameter_based ) {
-            $base_url = $home_url;
-        } else {
-            // Directory-based
-            $default_language_code = wpml_get_default_language();
-            if ( $default_language_code !== $lang_code ) {
-                $base_url = trailingslashit( $home_url ) . $lang_code;
-            } else {
-                $base_url = $home_url;
-            }
-            // Remove the language directory prefix from the already-parsed path.
-            // Using $parsed_url['path'] (via $url_path) keeps any query string out of the segments.
-            $base_path = trim( (string) wp_parse_url( $base_url, PHP_URL_PATH ), '/' );
-            if ( '' !== $base_path && strpos( $url_path, $base_path ) === 0 ) {
-                $url_path = trim( substr( $url_path, strlen( $base_path ) ), '/' );
-            }
+        // Rebuild the path, preserving the original trailing-slash behaviour.
+        $translated_path = '/' . implode( '/', $translated_segments );
+        if ( '/' === substr( $parsed_url['path'], -1 ) ) {
+            $translated_path = trailingslashit( $translated_path );
         }
 
-        // Handle empty path
-        if ( empty( $url_path ) ) {
-            $base_url = trailingslashit( $base_url );
+        // Reassemble using the original (WPML-provided) components.
+        $scheme = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '//';
+        $host   = $parsed_url['host'] ?? '';
+        $port   = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
+        $query  = isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '';
 
-            return $is_parameter_based
-                ? add_query_arg( [ 'lang' => $lang_code ], $base_url )
-                : $base_url;
-        }
-
-        // Translate path segments
-        $path_segments       = explode( '/', $url_path );
-        $translated_segments = $this->translate_path_segments( $path_segments, $lang_code );
-        $language_switcher_url = untrailingslashit( $base_url ) . '/' . implode( '/', $translated_segments );
-        // Apply WordPress trailing slash rules based on permalink structure
-        $language_switcher_url = user_trailingslashit( $language_switcher_url );
-
-        // If the language negotiation type is parameter-based, append the language code as a query parameter.
-        if ( $is_parameter_based ) {
-            $language_switcher_url = add_query_arg(
-                [ 'lang' => $lang_code ],
-                $language_switcher_url
-            );
-        }
+        $language_switcher_url = $scheme . $host . $port . $translated_path . $query;
 
         return apply_filters(
             'dokan_wpml_get_language_switcher_url',
             $language_switcher_url,
-            $path_segments,
+            $segments,
             $translated_segments,
             $lang,
-            $base_url
+            $url
         );
     }
 

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1908,7 +1908,7 @@ class Dokan_WPML {
     public function filter_language_switcher_url( $url, $lang ) {
         $lang_code = $lang['code'] ?? '';
         if ( empty( $url ) || empty( $lang_code ) ) {
-            return $url;
+            return $url; // Return early if URL or language code is empty
         }
 
         // Get language negotiation type
@@ -1967,9 +1967,12 @@ class Dokan_WPML {
         $translated_segments = $this->translate_path_segments( $path_segments, $lang_code );
         $language_switcher_url = untrailingslashit( $base_url ) . '/' . implode( '/', $translated_segments );
 
-        // Add language parameter for parameter-based negotiation
+        // If the language negotiation type is parameter-based, append the language code as a query parameter.
         if ( $is_parameter_based ) {
-            $language_switcher_url = add_query_arg( [ 'lang' => $lang_code ], $language_switcher_url );
+            $language_switcher_url = add_query_arg(
+                [ 'lang' => $lang_code ],
+                $language_switcher_url
+            );
         }
 
         return apply_filters(

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1916,14 +1916,43 @@ class Dokan_WPML {
             return $url; // Nothing to translate (e.g. home URL).
         }
 
-        // WPML has already encoded the correct scheme/host/lang-prefix/query for the
-        // target language. We only need to translate the Dokan endpoint path segments;
-        // unrecognised segments (lang code, store names, page slugs) pass through unchanged.
-        $segments            = explode( '/', trim( $parsed_url['path'], '/' ) );
+        // Resolve the WordPress install path (e.g. "store" for a subdirectory install)
+        // without WPML's language modifications. It must never be treated as a translatable
+        // slug, otherwise a subdirectory whose name collides with an endpoint slug (such as
+        // Dokan's default "store") would be rewritten and 404.
+        $this->disable_url_translation();
+        $home_path = trim( (string) wp_parse_url( home_url(), PHP_URL_PATH ), '/' );
+        $this->enable_url_translation();
+
+        $path     = trim( $parsed_url['path'], '/' );
+        $segments = '' === $path ? [] : explode( '/', $path );
+
+        // Split off the leading segments that must be kept verbatim: the install
+        // subdirectory and the language directory prefix (directory-based negotiation).
+        $preserved = [];
+
+        if ( '' !== $home_path ) {
+            $home_segments = explode( '/', $home_path );
+            if ( array_slice( $segments, 0, count( $home_segments ) ) === $home_segments ) {
+                $preserved = $home_segments;
+                $segments  = array_slice( $segments, count( $home_segments ) );
+            }
+        }
+
+        if ( isset( $segments[0] ) && $segments[0] === $lang_code ) {
+            $preserved[] = $lang_code;
+            array_shift( $segments );
+        }
+
+        // WPML has already encoded the correct scheme/host/lang-prefix/query for the target
+        // language; we only translate the remaining Dokan endpoint path segments.
         $translated_segments = $this->translate_path_segments( $segments, $lang_code );
 
+        $path_segments  = array_merge( $preserved, $segments );            // original, full path
+        $final_segments = array_merge( $preserved, $translated_segments ); // translated, full path
+
         // Rebuild the path, preserving the original trailing-slash behaviour.
-        $translated_path = '/' . implode( '/', $translated_segments );
+        $translated_path = '/' . implode( '/', $final_segments );
         if ( '/' === substr( $parsed_url['path'], -1 ) ) {
             $translated_path = trailingslashit( $translated_path );
         }
@@ -1939,8 +1968,8 @@ class Dokan_WPML {
         return apply_filters(
             'dokan_wpml_get_language_switcher_url',
             $language_switcher_url,
-            $segments,
-            $translated_segments,
+            $path_segments,
+            $final_segments,
             $lang,
             $url
         );

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1923,6 +1923,9 @@ class Dokan_WPML {
 
         // Extract path from URL
         $parsed_url = parse_url( $url );
+        if ( ! is_array( $parsed_url ) ) {
+            return $url;
+        }
         $url_path   = isset( $parsed_url['path'] ) ? trim( $parsed_url['path'], '/' ) : '';
         
         // Build base URL based on negotiation type

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1908,54 +1908,68 @@ class Dokan_WPML {
     public function filter_language_switcher_url( $url, $lang ) {
         $lang_code = $lang['code'] ?? '';
         if ( empty( $url ) || empty( $lang_code ) ) {
-            return $url; // Return early if URL or language code is empty
+            return $url;
         }
 
         // Get language negotiation type
         $language_negotiation_type = (int) apply_filters( 'wpml_setting', 1, 'language_negotiation_type' );
-            
-        // For domain-based language negotiation (type 2), WPML handles URLs correctly.
-        // This filter should not modify URLs in domain mode as it breaks the URL structure.
-        if ( WPML_LANGUAGE_NEGOTIATION_TYPE_DOMAIN === $language_negotiation_type ) {
-            return $url;
-        }
-        // Get home URL without WPML modifications.
+        $is_parameter_based        = ( WPML_LANGUAGE_NEGOTIATION_TYPE_PARAMETER === $language_negotiation_type );
+        $is_domain_based           = ( WPML_LANGUAGE_NEGOTIATION_TYPE_DOMAIN === $language_negotiation_type );
+        
+        // Get home URL without WPML modifications
         $this->disable_url_translation();
         $home_url = home_url();
         $this->enable_url_translation();
 
-        // Get default language code and check if the negotiation type is parameter-based.
-        $default_language_code     = wpml_get_default_language();
-        $is_parameter_based        = ( WPML_LANGUAGE_NEGOTIATION_TYPE_PARAMETER === $language_negotiation_type );
-
-        // If the language negotiation type is parameter-based, we need to use the home URL as the base URL.
-        if ( ! $is_parameter_based && $default_language_code !== $lang_code ) {
-            $base_url = trailingslashit( $home_url ) . $lang_code;
-        } else {
+        // Extract path from URL
+        $parsed_url = parse_url( $url );
+        $url_path   = isset( $parsed_url['path'] ) ? trim( $parsed_url['path'], '/' ) : '';
+        
+        // Build base URL based on negotiation type
+        if ( $is_domain_based ) {
+            $domain_info = apply_filters( 'wpml_setting', [], 'language_domains' );
+            if ( ! empty( $domain_info[ $lang_code ] ) ) {
+                $base_url = $domain_info[ $lang_code ];
+                if ( ! preg_match( '#^https?://#i', $base_url ) ) {
+                    $base_url = 'https://' . $base_url;
+                }
+            } else {
+                return $url;
+            }
+        } elseif ( $is_parameter_based ) {
             $base_url = $home_url;
+            // Remove query parameters from path
+            if ( strpos( $url_path, '?' ) !== false ) {
+                $url_path = explode( '?', $url_path, 2 )[0];
+            }
+        } else {
+            // Directory-based
+            $default_language_code = wpml_get_default_language();
+            if ( $default_language_code !== $lang_code ) {
+                $base_url = trailingslashit( $home_url ) . $lang_code;
+            } else {
+                $base_url = $home_url;
+            }
+            // Remove base URL from path for directory-based
+            $url_path = trim( str_replace( $base_url, '', $url ), '/' );
         }
 
-        // Remove query parameters for parameter-based negotiation.
-        $url_path = trim( str_replace( $base_url, '', $url ), '/' );
-        if ( $is_parameter_based && strpos( $url_path, '?' ) !== false ) {
-            $url_path = explode( '?', $url_path, 2 )[0];
-        }
-
+        // Handle empty path
         if ( empty( $url_path ) ) {
-            return $url;
+            if ( $is_parameter_based ) {
+                return add_query_arg( [ 'lang' => $lang_code ], trailingslashit( $base_url ) );
+            }
+            return trailingslashit( $base_url );
         }
 
-        // Translate path segments to the target language.
-        $path_segments         = explode( '/', $url_path );
-        $translated_segments   = $this->translate_path_segments( $path_segments, $lang_code );
-        $language_switcher_url = trailingslashit( $base_url ) . trailingslashit( implode( '/', $translated_segments ) );
+        // Translate path segments
+        $path_segments       = explode( '/', $url_path );
+        $translated_segments = $this->translate_path_segments( $path_segments, $lang_code );
+        $language_switcher_url = untrailingslashit( $base_url ) . '/' . implode( '/', $translated_segments );
 
-        // If the language negotiation type is parameter-based, append the language code as a query parameter.
+        // Add language parameter for parameter-based negotiation
         if ( $is_parameter_based ) {
-            $language_switcher_url = add_query_arg(
-                [ 'lang' => $lang_code ],
-                $language_switcher_url
-            );
+            $language_switcher_url = add_query_arg( [ 'lang' => $lang_code ], $language_switcher_url );
         }
 
         return apply_filters(

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1913,9 +1913,13 @@ class Dokan_WPML {
 
         // Get language negotiation type
         $language_negotiation_type = (int) apply_filters( 'wpml_setting', 1, 'language_negotiation_type' );
-        $is_parameter_based        = ( WPML_LANGUAGE_NEGOTIATION_TYPE_PARAMETER === $language_negotiation_type );
-        $is_domain_based           = ( WPML_LANGUAGE_NEGOTIATION_TYPE_DOMAIN === $language_negotiation_type );
-        
+        $is_parameter_based        = false;
+        $is_domain_based           = false;
+        if ( defined( 'WPML_LANGUAGE_NEGOTIATION_TYPE_PARAMETER' ) && defined( 'WPML_LANGUAGE_NEGOTIATION_TYPE_DOMAIN' ) ) {
+            $is_parameter_based = ( WPML_LANGUAGE_NEGOTIATION_TYPE_PARAMETER === $language_negotiation_type );
+            $is_domain_based    = ( WPML_LANGUAGE_NEGOTIATION_TYPE_DOMAIN === $language_negotiation_type );
+        }
+
         // Get home URL without WPML modifications
         $this->disable_url_translation();
         $home_url = home_url();
@@ -1954,8 +1958,12 @@ class Dokan_WPML {
             } else {
                 $base_url = $home_url;
             }
-            // Remove base URL from path for directory-based
-            $url_path = trim( str_replace( $base_url, '', $url ), '/' );
+            // Remove the language directory prefix from the already-parsed path.
+            // Using $parsed_url['path'] (via $url_path) keeps any query string out of the segments.
+            $base_path = trim( (string) wp_parse_url( $base_url, PHP_URL_PATH ), '/' );
+            if ( '' !== $base_path && strpos( $url_path, $base_path ) === 0 ) {
+                $url_path = trim( substr( $url_path, strlen( $base_path ) ), '/' );
+            }
         }
 
         // Handle empty path

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1931,7 +1931,8 @@ class Dokan_WPML {
             if ( ! empty( $domain_info[ $lang_code ] ) ) {
                 $base_url = $domain_info[ $lang_code ];
                 if ( ! preg_match( '#^https?://#i', $base_url ) ) {
-                    $base_url = 'https://' . $base_url;
+                    $scheme   = wp_parse_url( $home_url, PHP_URL_SCHEME ) ?: 'https';
+                    $base_url = $scheme . '://' . $base_url;
                 }
             } else {
                 return $url;
@@ -1966,6 +1967,8 @@ class Dokan_WPML {
         $path_segments       = explode( '/', $url_path );
         $translated_segments = $this->translate_path_segments( $path_segments, $lang_code );
         $language_switcher_url = untrailingslashit( $base_url ) . '/' . implode( '/', $translated_segments );
+        // Apply WordPress trailing slash rules based on permalink structure
+        $language_switcher_url = user_trailingslashit( $language_switcher_url );
 
         // If the language negotiation type is parameter-based, append the language code as a query parameter.
         if ( $is_parameter_based ) {

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -1946,10 +1946,6 @@ class Dokan_WPML {
             }
         } elseif ( $is_parameter_based ) {
             $base_url = $home_url;
-            // Remove query parameters from path
-            if ( strpos( $url_path, '?' ) !== false ) {
-                $url_path = explode( '?', $url_path, 2 )[0];
-            }
         } else {
             // Directory-based
             $default_language_code = wpml_get_default_language();
@@ -1968,10 +1964,11 @@ class Dokan_WPML {
 
         // Handle empty path
         if ( empty( $url_path ) ) {
-            if ( $is_parameter_based ) {
-                return add_query_arg( [ 'lang' => $lang_code ], trailingslashit( $base_url ) );
-            }
-            return trailingslashit( $base_url );
+            $base_url = trailingslashit( $base_url );
+
+            return $is_parameter_based
+                ? add_query_arg( [ 'lang' => $lang_code ], $base_url )
+                : $base_url;
         }
 
         // Translate path segments


### PR DESCRIPTION
Closes: https://github.com/getdokan/dokan-wpml/issues/112
https://github.com/getdokan/dokan-wpml/issues/116

Fix: Corrected broken language switcher URLs in WPML domain-based language mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language switcher URL generation across domain-based, parameter-based, and directory-based setups to prevent incorrect redirects and preserve translation context.

* **Improvements**
  * Enhanced path handling with more accurate per-segment translation and URL reconstruction, including correct trailing-slash behavior and proper query handling for parameter-based sites (including empty-path cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->