### PR TITLE
fix: always declare WooCommerce feature compatibility (HPOS, blocks)

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -84,6 +84,11 @@ class Dokan_WPML {
     public function __construct() {
         register_activation_hook( __FILE__, [ $this, 'dependency_missing_notice' ] );
 
+        // Declare WooCommerce feature compatibility (HPOS, cart/checkout blocks).
+        // Registered here — not inside the dependency-gated plugins_loaded() —
+        // so the declaration always runs even when WPML is inactive.
+        add_action( 'before_woocommerce_init', [ $this, 'declare_woocommerce_feature_compatibility' ] );
+
         // Localize our plugin
         add_action( 'init', [ $this, 'localization_setup' ] );
 
@@ -126,7 +131,6 @@ class Dokan_WPML {
 
 		// load appsero tracker
 		$this->appsero_init_tracker();
-        add_action( 'before_woocommerce_init', [ $this, 'declare_woocommerce_feature_compatibility' ] );
 
 		// Load all actions hook
 		add_filter( 'dokan_forced_load_scripts', [ $this, 'load_scripts_and_style' ] );


### PR DESCRIPTION
## Problem

**Dokan – WPML Integration** appears under the WooCommerce Plugins-page filter **"Incompatible with WooCommerce features (1)"** (HPOS / cart & checkout blocks).

The plugin *does* declare compatibility in `declare_woocommerce_feature_compatibility()`, but the `add_action( 'before_woocommerce_init', ... )` that registers it lived **inside `plugins_loaded()`, after the `check_dependency()` early-return**. When WPML (`SitePress`) or Dokan is inactive, `plugins_loaded()` bails before reaching the registration, so the declaration never runs and WooCommerce marks the plugin as incompatible.

Because compatibility is a static fact about the plugin's code (it *is* HPOS-safe), gating the declaration behind the WPML dependency produces a misleading false-positive.

## Reproduction

The activation guard self-deactivates the plugin when WPML is absent, so the failing state is reached by:

1. Activate WooCommerce (HPOS enabled), Dokan, **WPML Multilingual CMS**, then **Dokan – WPML Integration**.
2. **Deactivate only WPML Multilingual CMS** — Dokan-WPML stays active.
3. **Plugins → Installed Plugins** now shows **"Incompatible with WooCommerce features (1)"**.

## Fix

Move the `before_woocommerce_init` registration into the constructor, which always runs regardless of dependency state. The callback already guards on `class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class )`, so it stays a safe no-op when WooCommerce is absent. Timing is unaffected — the constructor runs at file-include time, well before `before_woocommerce_init` fires on `init:0`.

## Verification

With the fix applied and the plugin in the formerly-broken state (Dokan-WPML active, WPML inactive), WooCommerce's `FeaturesController` now reports:

- `custom_order_tables` (HPOS) → **COMPATIBLE**
- `cart_checkout_blocks` → **COMPATIBLE**

`php -l` passes with no syntax errors.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WooCommerce compatibility detection so the extension can register supported features earlier during startup.
  * Helped ensure compatibility information is available even when related integrations are not fully loaded yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->