### PR TITLE
chore: Release version 1.1.14

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v1.1.14 -> Jul 01, 2026
+---------------------------
+- **fix:** Corrected broken language switcher URLs when WPML uses a different domain per language.
+- **fix:** Fixed the plugin being marked as incompatible with WooCommerce features (HPOS and cart & checkout blocks).
+
 v1.1.13 -> Jan 08, 2026
 ---------------------------
 - **fix:** Resolved vendor dashboard queries duplication for Dokan WPML.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
-v1.1.14 -> Jul 01, 2026
+v1.1.14 -> Jul 02, 2026
 ---------------------------
 - **fix:** Corrected broken language switcher URLs when WPML uses a different domain per language.
 - **fix:** Fixed the plugin being marked as incompatible with WooCommerce features (HPOS and cart & checkout blocks).
+- **fix:** Corrected vendor dashboard navigation URLs for the new UI when WPML is active.
 
 v1.1.13 -> Jan 08, 2026
 ---------------------------

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -3,7 +3,7 @@
  * Plugin Name: Dokan - WPML Integration
  * Plugin URI: https://wedevs.com/
  * Description: WPML and Dokan compatible package
- * Version: 1.1.13
+ * Version: 1.1.14
  * Author: weDevs
  * Author URI: https://wedevs.com/
  * Text Domain: dokan-wpml

--- a/languages/dokan-wpml.pot
+++ b/languages/dokan-wpml.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-01T10:02:32+00:00\n"
+"POT-Creation-Date: 2026-07-02T05:46:25+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: dokan-wpml\n"
@@ -47,7 +47,7 @@ msgstr ""
 msgid "<b>Dokan - WPML Integration</b> requires %1$s WPML Multilingual CMS %2$s to be installed & activated!"
 msgstr ""
 
-#: dokan-wpml.php:1741
+#: dokan-wpml.php:1754
 #, php-format
 msgid "Dokan WPML - Error on registering vendor store URL endpoint: %s"
 msgstr ""

--- a/languages/dokan-wpml.pot
+++ b/languages/dokan-wpml.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Dokan - WPML Integration 1.1.13\n"
+"Project-Id-Version: Dokan - WPML Integration 1.1.14\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/dokan-wpml\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-01-08T09:04:22+00:00\n"
+"POT-Creation-Date: 2026-07-01T10:02:32+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.11.0\n"
+"X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: dokan-wpml\n"
 
 #. Plugin Name of the plugin
@@ -36,15 +36,18 @@ msgid "weDevs"
 msgstr ""
 
 #. translators: %1$s: opening anchor tag, %2$s: closing anchor tag
-#: dokan-wpml.php:283
+#: dokan-wpml.php:287
+#, php-format
 msgid "<b>Dokan - WPML Integration</b> requires %1$s Dokan plugin %2$s to be installed & activated!"
 msgstr ""
 
 #. translators: %1$s: opening anchor tag, %2$s: closing anchor tag
-#: dokan-wpml.php:289
+#: dokan-wpml.php:293
+#, php-format
 msgid "<b>Dokan - WPML Integration</b> requires %1$s WPML Multilingual CMS %2$s to be installed & activated!"
 msgstr ""
 
-#: dokan-wpml.php:1737
+#: dokan-wpml.php:1741
+#, php-format
 msgid "Dokan WPML - Error on registering vendor store URL endpoint: %s"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dokan-wpml",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "WPML compatibility for dokan plugin",
   "author": "weDevs",
   "license": "GPL",

--- a/readme.txt
+++ b/readme.txt
@@ -52,10 +52,11 @@ nothing here
 
 == Changelog ==
 
-v1.1.14 -> Jul 01, 2026
+v1.1.14 -> Jul 02, 2026
 ---------------------------
 - **fix:** Corrected broken language switcher URLs when WPML uses a different domain per language.
 - **fix:** Fixed the plugin being marked as incompatible with WooCommerce features (HPOS and cart & checkout blocks).
+- **fix:** Corrected vendor dashboard navigation URLs for the new UI when WPML is active.
 
 v1.1.13 -> Jan 08, 2026
 ---------------------------

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tested up to: 6.8.2
 WC requires at least: 8.5.0
 WC tested up to: 10.2.2
 Requires PHP: 7.4
-Stable tag: 1.1.13
+Stable tag: 1.1.14
 License: GPL v2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,6 +51,11 @@ Ans: Yes, you can contact the WPML team. They offer translation service via thir
 nothing here
 
 == Changelog ==
+
+v1.1.14 -> Jul 01, 2026
+---------------------------
+- **fix:** Corrected broken language switcher URLs when WPML uses a different domain per language.
+- **fix:** Fixed the plugin being marked as incompatible with WooCommerce features (HPOS and cart & checkout blocks).
 
 v1.1.13 -> Jan 08, 2026
 ---------------------------


### PR DESCRIPTION
### Closes

* Closes getdokan/plugin-internal-tasks#2187



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed language switcher links when different domains are used for each language.
  * Corrected the plugin’s WooCommerce compatibility status so it no longer shows incorrect incompatibility warnings for HPOS and cart/checkout blocks.

* **Chores**
  * Updated the plugin to version 1.1.14 and refreshed the release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
