### PR TITLE
fix: register Dokan script handles with WPML's JS string scanner

### DIFF
--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -99,6 +99,15 @@ class Dokan_WPML {
         add_action( 'updated_option', [ $this, 'clear_option_cache' ] );
         add_action( 'added_option', [ $this, 'clear_option_cache' ] );
         add_action( 'deleted_option', [ $this, 'clear_option_cache' ] );
+
+        // WPML's JS string scanner drops strings from any .js file it cannot map
+        // to a script handle, and it only learns handle mappings from scripts
+        // actually printed on a page visited while WPML was active. Dokan's
+        // vendor-dashboard bundles never print for the admin running the scan,
+        // so their strings never reach String Translation. Register the
+        // mappings ourselves from the handles Dokan registers on the front end.
+        add_action( 'wp_enqueue_scripts', [ $this, 'register_dokan_scripts_for_wpml_js_scanner' ], 9999 );
+        add_action( 'wpml_reset_plugins_before', [ $this, 'clear_wpml_js_script_registry_hash' ] );
     }
 
     /**
@@ -2008,6 +2017,94 @@ class Dokan_WPML {
         }
 
         return $path_segments;
+    }
+
+    /**
+     * Feed Dokan script handle-to-file mappings to WPML's JS string scanner.
+     *
+     * WPML String Translation's JS scanner (\WPML\ST\StringsScanning\JS\Scanner)
+     * discards every string found in a .js file unless its ScriptRegistry can
+     * map the file back to a registered script handle. WPML populates that
+     * registry from the script_loader_tag filter, so it only knows scripts that
+     * were actually printed on a page someone visited while WPML was active.
+     * Dokan's vendor-dashboard bundles (shipping, verification, etc.) only
+     * print for logged-in vendors, so the admin running the scan never creates
+     * the mapping and those strings never appear in String Translation
+     * (see getdokan/dokan-pro#5783). Registering every Dokan handle directly
+     * lets the scanner keep the strings under the correct per-handle JED
+     * domain, so translations also flow back to the browser.
+     *
+     * @since 1.1.16
+     *
+     * @return void
+     */
+    public function register_dokan_scripts_for_wpml_js_scanner() {
+        if ( ! class_exists( \WPML\ST\StringsScanning\JS\ScriptRegistry::class ) ) {
+            return;
+        }
+
+        $base_urls = [];
+
+        if ( defined( 'DOKAN_FILE' ) ) {
+            $base_urls[] = plugin_dir_url( DOKAN_FILE );
+        }
+
+        if ( defined( 'DOKAN_PRO_FILE' ) ) {
+            $base_urls[] = plugin_dir_url( DOKAN_PRO_FILE );
+        }
+
+        if ( ! $base_urls ) {
+            return;
+        }
+
+        $script_map = [];
+
+        foreach ( wp_scripts()->registered as $handle => $script ) {
+            if ( empty( $script->src ) || ! is_string( $script->src ) ) {
+                continue;
+            }
+
+            foreach ( $base_urls as $base_url ) {
+                if ( 0 === strpos( $script->src, $base_url ) ) {
+                    $script_map[ $handle ] = $script->src;
+                    break;
+                }
+            }
+        }
+
+        if ( ! $script_map ) {
+            return;
+        }
+
+        // ScriptRegistry::register() writes options on every call — skip when
+        // the map is unchanged since the last successful registration. Sorted
+        // so registration order can never produce a false "changed" hash.
+        ksort( $script_map );
+        $hash = md5( wp_json_encode( $script_map ) );
+
+        if ( get_option( 'dokan_wpml_js_script_registry_hash' ) === $hash ) {
+            return;
+        }
+
+        \WPML\ST\StringsScanning\JS\ScriptRegistry::register( $script_map );
+
+        // Autoloaded: read on every front-end request and only 32 bytes —
+        // autoloading saves the extra query.
+        update_option( 'dokan_wpml_js_script_registry_hash', $hash, true );
+    }
+
+    /**
+     * Forget the last registered script map when WPML resets its data.
+     *
+     * WPML "Reset and remove all data" drops the ScriptRegistry options, so
+     * the next front-end request must re-register regardless of the hash.
+     *
+     * @since 1.1.16
+     *
+     * @return void
+     */
+    public function clear_wpml_js_script_registry_hash() {
+        delete_option( 'dokan_wpml_js_script_registry_hash' );
     }
 } // Dokan_WPML
 

--- a/dokan-wpml.php
+++ b/dokan-wpml.php
@@ -108,6 +108,13 @@ class Dokan_WPML {
         // mappings ourselves from the handles Dokan registers on the front end.
         add_action( 'wp_enqueue_scripts', [ $this, 'register_dokan_scripts_for_wpml_js_scanner' ], 9999 );
         add_action( 'wpml_reset_plugins_before', [ $this, 'clear_wpml_js_script_registry_hash' ] );
+
+        // WPML's registry can also disappear without wpml_reset_plugins_before
+        // firing — e.g. String Translation uninstalled and reinstalled, or its
+        // options lost in a migration. Re-registering after (re)activation of
+        // String Translation or this plugin costs one pass and self-heals those.
+        add_action( 'activated_plugin', [ $this, 'clear_hash_when_string_translation_activates' ] );
+        register_activation_hook( __FILE__, [ $this, 'clear_wpml_js_script_registry_hash' ] );
     }
 
     /**
@@ -2057,7 +2064,8 @@ class Dokan_WPML {
             return;
         }
 
-        $script_map = [];
+        $script_map   = [];
+        $relative_map = [];
 
         foreach ( wp_scripts()->registered as $handle => $script ) {
             if ( empty( $script->src ) || ! is_string( $script->src ) ) {
@@ -2066,7 +2074,8 @@ class Dokan_WPML {
 
             foreach ( $base_urls as $base_url ) {
                 if ( 0 === strpos( $script->src, $base_url ) ) {
-                    $script_map[ $handle ] = $script->src;
+                    $script_map[ $handle ]   = $script->src;
+                    $relative_map[ $handle ] = substr( $script->src, strlen( $base_url ) );
                     break;
                 }
             }
@@ -2077,16 +2086,27 @@ class Dokan_WPML {
         }
 
         // ScriptRegistry::register() writes options on every call — skip when
-        // the map is unchanged since the last successful registration. Sorted
-        // so registration order can never produce a false "changed" hash.
-        ksort( $script_map );
-        $hash = md5( wp_json_encode( $script_map ) );
+        // the map is unchanged since the last successful registration. The hash
+        // covers plugin-relative paths, not full URLs: WPML rewrites plugins_url()
+        // per request in domain-per-language mode, so absolute URLs would hash
+        // differently on every language domain and thrash the guard (WPML itself
+        // stores relative paths, so the registered data is domain-independent).
+        // Sorted so registration order can never produce a false "changed" hash.
+        ksort( $relative_map );
+        $hash = md5( wp_json_encode( $relative_map ) );
 
         if ( get_option( 'dokan_wpml_js_script_registry_hash' ) === $hash ) {
             return;
         }
 
-        \WPML\ST\StringsScanning\JS\ScriptRegistry::register( $script_map );
+        // ScriptRegistry is a WPML internal, not a public API — guard against a
+        // future signature/behavior change fataling every front-end request. On
+        // failure the hash is not written, so the call retries once WPML is fixed.
+        try {
+            \WPML\ST\StringsScanning\JS\ScriptRegistry::register( $script_map );
+        } catch ( \Throwable $e ) {
+            return;
+        }
 
         // Autoloaded: read on every front-end request and only 32 bytes —
         // autoloading saves the extra query.
@@ -2105,6 +2125,26 @@ class Dokan_WPML {
      */
     public function clear_wpml_js_script_registry_hash() {
         delete_option( 'dokan_wpml_js_script_registry_hash' );
+    }
+
+    /**
+     * Re-register scripts after WPML String Translation is (re)activated.
+     *
+     * Uninstalling String Translation drops its ScriptRegistry options without
+     * firing wpml_reset_plugins_before — after a reinstall the stored hash
+     * would still match and re-registration would never run. Clearing it on
+     * activation costs at most one extra registration pass.
+     *
+     * @since 1.1.16
+     *
+     * @param string $plugin Path of the activated plugin, relative to plugins dir.
+     *
+     * @return void
+     */
+    public function clear_hash_when_string_translation_activates( $plugin ) {
+        if ( false !== strpos( (string) $plugin, 'wpml-string-translation' ) ) {
+            $this->clear_wpml_js_script_registry_hash();
+        }
     }
 } // Dokan_WPML
 


### PR DESCRIPTION
Fixes getdokan/dokan-pro#5783
WPML errata: https://wpml.org/errata/dokan-pro-some-strings-are-not-translatable/

## Problem

Strings that live only in Dokan's JavaScript bundles — e.g. **Zone Name** and **Region(s)** on `/dashboard/settings/shipping/`, and the verification settings page — can never be found in **WPML → String Translation**, so multilingual sites cannot translate them. The strings themselves are correctly wrapped in `__( '…', 'dokan' )`, present in `dokan.pot`, and registered via `wp_set_script_translations()` — nothing is wrong in dokan-lite/dokan-pro.

## Root cause (in WPML String Translation)

1. WPML's JS scanner (`WPML\ST\StringsScanning\JS\Scanner`) **does** parse minified JS bundles and extract the strings — but then it silently discards everything from a file unless its `ScriptRegistry` can map that file back to a registered script handle:
   ```php
   list( $handle, $textdomain ) = ScriptRegistry::getHandleAndTextdomainByPath( $file );
   if ( ! $handle ) {
       return; // all extracted strings dropped, no warning
   }
   ```
2. WPML populates that registry passively, from the `script_loader_tag` filter — i.e. only for scripts **actually printed on a page visited while WPML was active**.
3. Dokan's vendor-dashboard bundles only print for **logged-in vendors**. The admin who runs the scan never renders those pages, the mapping never exists, and the strings are dropped on every scan.

WPML's own suggested workaround confirms this chain: *“Enable Scan strings in JavaScript files, **visit the page containing the string**, then scan again”* — impractical for pages that require a vendor login, and per-page/per-update manual work.

## Fix

On front-end requests (`wp_enqueue_scripts` @ 9999, after all Dokan registrations), collect every **registered** script handle whose `src` belongs to dokan-lite or dokan-pro (derived from `DOKAN_FILE` / `DOKAN_PRO_FILE`, so module bundles and renamed plugin folders are covered) and hand the map to WPML's own `ScriptRegistry::register()`. Registered ≠ printed — Dokan registers all its scripts on every front-end request, so one visit to any page maps everything, including vendor-only bundles.

This also stores the scanned strings under the correct per-handle JED domain (`dokan-{handle}`), which is what WPML uses to build the JSON served back to `wp.i18n` — so translations flow end-to-end to the browser.

Details:
- Guarded by `class_exists` — no-op when String Translation is inactive or predates the JS scanner.
- A 32-byte autoloaded option holds an md5 of the (sorted) map; re-registration is skipped while the map is unchanged, so the steady-state cost is one autoloaded option read.
- `wpml_reset_plugins_before` clears the hash so WPML's “Reset and remove all data” triggers a fresh registration on the next request.

## Test steps (verified on a live WPML + Loco-free site)

1. With this fix active, load any front-end page once. Verify `WPML(js_script_registry)` now contains the Dokan handles (222 on the test site), including `dokan-pro-vue-frontend-shipping`.
2. **WPML → Theme and plugins localization** → scan Dokan Pro.
3. **WPML → String Translation** → search “Zone Name” — it now appears (before: never findable). Domain: `dokan-dokan-pro-vue-frontend-shipping`.
4. Translate it (e.g. bn: জোন নাম) and reload `/dashboard/settings/shipping/` as a vendor in that language → the header renders translated, with no Loco/JSON files present, proving WPML-only delivery works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known limitations

- **Admin-only Dokan bundles are not mapped** — the hook runs on `wp_enqueue_scripts` (front end). Admin screens the translating admin actually visits are covered by WPML's own passive mapping, so this only affects admin-only scripts on pages nobody opens before scanning; front-end/vendor-dashboard strings (the reported bug) are fully covered.
- **CDN setups that rewrite `plugins_url` to an external host**: WPML's `ScriptRegistry` drops external-host entries by design; this matches WPML's native passive behavior (which fails identically), so it is parity, not a regression.
